### PR TITLE
Mute spotify stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 ## Linux Spotify ad muter
-Listens to track changes with dbus. Assumes pulseaudio, and mutes master during ads (i.e. not just spotify's stream! [1]).
+Listens to track changes with dbus. Assumes pulseaudio, and mutes all spotify streams during ads. If no streams can be detected the master is muted as a fallback.
 
 License: BSD. Based on <https://muffinresearch.co.uk/linux-spotify-track-notifier-with-added-d-bus-love/>.
-
-[1] TODO: only mute spotify stream, read pavucontrol source code to figure out how. Currently mutes pulseaudio using `amixer -D pulse sset Master {off|on}`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Linux Spotify ad muter
-Listens to track changes with dbus. Assumes pulseaudio, and mutes all spotify streams during ads. If no streams can be detected the master is muted as a fallback.
+
+Listens to track changes with dbus. Assumes pulseaudio or pipewire, and mutes all spotify streams during ads. If no streams can be detected the master is muted as a fallback.
 
 License: BSD. Based on <https://muffinresearch.co.uk/linux-spotify-track-notifier-with-added-d-bus-love/>.

--- a/spotifynoads.py
+++ b/spotifynoads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/spotifynoads.py
+++ b/spotifynoads.py
@@ -84,7 +84,12 @@ class PlayerAdMuter(object):
                     binary = part.split('application.process.binary = ')[1].split('"')[1]
                 # sink latency
                 elif 'current latency: ' in part:
-                    latency = float(part.split('current latency: ')[1].split(' ms')[0])
+                    l = part.split('current latency: ')[1].split(' ms')[0]
+                    try:
+                        latency = float(l)
+                    # some old versions of pulse audio localize the output kind of weird and use commas for floating point values
+                    except ValueError:
+                        latency = float(l.replace(',', '.'))
                 else:
                     continue
             if binary == self.app_name:


### PR DESCRIPTION
Hi Brendan,

I added the ability to mute only spotify streams. Seems to work with spotify quite flawlessly, but I had no opportunity to test with youtubemusic. 

The solution takes the latency of the streams into account, but even as this does not cut off as much sound as muting the master this may need fine tuning. If you are willing to have a look, please give me a feedback.

Holger